### PR TITLE
Lglen/async Async methods support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # jfaas
 
+`jfaas` is a tool for running java apps on Yagna. It delegates calls and executes on the remote machine.
+
+See README in modules below for more detailed information. In particular see `jfaas-local-example` for information on how to use it.
+
 `jfaas-proxy` -- the library required by the caller java app. Add it to your classpath.
 
 `jfaas-runner` -- the java app that calls the target client jar. Requires the client jar in the classpath.

--- a/jfaas-local-example/pom.xml
+++ b/jfaas-local-example/pom.xml
@@ -19,7 +19,8 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
+		<artifactId>maven-compiler-plugin</artifactId>
+		<version>3.1</version>
                 <configuration>
                     <source>8</source>
                     <target>8</target>

--- a/jfaas-local-example/src/main/java/network/golem/jfaas/example/local/FutureResult.java
+++ b/jfaas-local-example/src/main/java/network/golem/jfaas/example/local/FutureResult.java
@@ -1,0 +1,41 @@
+package network.golem.jfaas.example.local;
+
+import java.io.Serializable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+public class FutureResult<V> implements Future<V>, Serializable {
+    private V result;
+
+    public FutureResult(V result) {
+        this.result = result;
+    }
+
+    @Override
+    public boolean cancel(boolean mayInterruptIfRunning) {
+        return false;
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return false;
+    }
+
+    @Override
+    public boolean isDone() {
+        return true;
+    }
+
+    @Override
+    public V get() throws InterruptedException, ExecutionException {
+        return result;
+    }
+
+    @Override
+    public V get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+        return result;
+    }
+}
+

--- a/jfaas-local-example/src/main/java/network/golem/jfaas/example/local/ObjectTest3.java
+++ b/jfaas-local-example/src/main/java/network/golem/jfaas/example/local/ObjectTest3.java
@@ -1,0 +1,14 @@
+package network.golem.jfaas.example.local;
+
+import network.golem.jfaas.proxy.JfaasProxy;
+import java.util.concurrent.Future;
+
+public class ObjectTest3 {
+    public static void main(String[] args) throws Exception {
+        System.out.println("testing hello+world");
+        ObjectTestBeanLocal proxy = JfaasProxy.getProxy(ObjectTestBeanLocal.class, ObjectTestBean.class);
+	Future<ObjectTestReturn> future = proxy.convertAsync(new ObjectTestArgument("hello", "world"));
+	ObjectTestReturn result = future.get();
+        System.out.println("result: "+result.getValue());
+    }
+}

--- a/jfaas-local-example/src/main/java/network/golem/jfaas/example/local/ObjectTestBean.java
+++ b/jfaas-local-example/src/main/java/network/golem/jfaas/example/local/ObjectTestBean.java
@@ -1,5 +1,7 @@
 package network.golem.jfaas.example.local;
 
+import java.util.concurrent.Future;
+
 public class ObjectTestBean implements ObjectTestBeanLocal {
     @Override
     public ObjectTestReturn convert(ObjectTestArgument argument) {
@@ -9,5 +11,10 @@ public class ObjectTestBean implements ObjectTestBeanLocal {
     @Override
     public ObjectTestReturn convertFail(ObjectTestArgument argument) throws ObjectTestException {
         throw new ObjectTestException();
+    }
+
+    @Override
+    public Future<ObjectTestReturn> convertAsync(ObjectTestArgument argument) {
+        return new FutureResult<ObjectTestReturn>(convert(argument));
     }
 }

--- a/jfaas-local-example/src/main/java/network/golem/jfaas/example/local/ObjectTestBeanLocal.java
+++ b/jfaas-local-example/src/main/java/network/golem/jfaas/example/local/ObjectTestBeanLocal.java
@@ -1,6 +1,9 @@
 package network.golem.jfaas.example.local;
 
+import java.util.concurrent.Future;
+
 public interface ObjectTestBeanLocal {
     public ObjectTestReturn convert(ObjectTestArgument argument);
     public ObjectTestReturn convertFail(ObjectTestArgument argument) throws ObjectTestException;
+    public Future<ObjectTestReturn> convertAsync(ObjectTestArgument argument);
 }

--- a/jfaas-proxy/README.md
+++ b/jfaas-proxy/README.md
@@ -29,10 +29,24 @@ The return value is expected in the file `${callId}.invocation.return`.
 
 At the moment an execution of the external command is synchronuous - when the command ends, then a return file is expected.
 
+### Async
+
+A method is executed asynchronously if it returns `Future<>`. See `jfaas-local-example` for a demonstration.
+
 ## Beans
 
 A target bean must be POJO. All method parameters and return values must be Serializable. A target bean instance is created with an empty constructor on the remote side.
 
+A bean must expose an interface with delegated methods.
+
 ## Output
 
 The standard output and error from the external command execution is appended to the standard output and error of the calling jvm.
+
+## Requirements
+
+1. All arguments and return values are serialized. 
+2. The target object is created with default empty constructor.
+3. Only public methods are eligible for delegate calls.
+4. The method is distinguished by a name. Make sure your delegated call does not use overloaded method.
+5. Make sure that all required classes are contained in the client jar.

--- a/jfaas-proxy/README.md
+++ b/jfaas-proxy/README.md
@@ -49,4 +49,4 @@ The standard output and error from the external command execution is appended to
 2. The target object is created with default empty constructor.
 3. Only public methods are eligible for delegate calls.
 4. The method is distinguished by a name. Make sure your delegated call does not use overloaded method.
-5. Make sure that all required classes are contained in the client jar.
+5. Make sure that all required classes are contained in the client jar. `jfaas-runner.jar` will be added to the class path on a remote side.

--- a/jfaas-proxy/src/main/java/network/golem/jfaas/proxy/FutureImpl.java
+++ b/jfaas-proxy/src/main/java/network/golem/jfaas/proxy/FutureImpl.java
@@ -1,0 +1,77 @@
+package network.golem.jfaas.proxy;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+public class FutureImpl<V> implements Future<V> {
+    private boolean done = false;
+    private V value = null;
+    private Throwable error = null;
+    final Object mutex = new Object();
+
+    @Override
+    public boolean cancel(boolean mayInterruptIfRunning) {
+        synchronized (mutex) {
+            return false; //not implemented
+        }
+    }
+
+    @Override
+    public boolean isCancelled() {
+        synchronized (mutex) {
+            return false; //not implemented
+        }
+    }
+
+    @Override
+    public boolean isDone() {
+        synchronized (mutex) {
+            return done;
+        }
+    }
+
+    @Override
+    public V get() throws InterruptedException, ExecutionException {
+        synchronized (mutex) {
+            if (!done) {
+                mutex.wait();
+            }
+            if (error == null)
+                return value;
+            else
+                throw new ExecutionException(error);
+        }
+    }
+
+    @Override
+    public V get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+        synchronized (mutex) {
+            if (!done) {
+                mutex.wait(unit.toMillis(timeout));
+                if (!done) {
+                    throw new TimeoutException();
+                }
+            }
+            if (error == null)
+                return value;
+            else
+                throw new ExecutionException(error);
+        }
+    }
+
+    void setValue(V value) {
+        synchronized (mutex) {
+            done = true;
+            this.value = value;
+        }
+    }
+
+    void setException(Throwable throwable) {
+        synchronized (mutex) {
+            done = true;
+            this.error = throwable;
+        }
+    }
+}

--- a/jfaas-runner/src/test/java/network/golem/jfaas/runner/ObjectTest.java
+++ b/jfaas-runner/src/test/java/network/golem/jfaas/runner/ObjectTest.java
@@ -20,7 +20,7 @@ public class ObjectTest {
         String tempDir = System.getProperty("java.io.tmpdir");
 
         ObjectTestArgument argument = new ObjectTestArgument("object", "test");
-        Object[] invocation = {"network.golem.jfaas.runner.ObjectTestBeanLocal", "network.golem.jfaas.runner.ObjectTestBean", "convert", new Object[]{argument}};
+        Object[] invocation = {null, "network.golem.jfaas.runner.ObjectTestBean", "convert", new Object[]{argument}};
 
         Path invocationFilePath = Paths.get(tempDir, invocationId + ".invocation");
         try (OutputStream fileOutputStream = Files.newOutputStream(invocationFilePath)) {
@@ -41,7 +41,7 @@ public class ObjectTest {
         String tempDir = System.getProperty("java.io.tmpdir");
 
         ObjectTestArgument argument = new ObjectTestArgument("object", "test");
-        Object[] invocation = {"network.golem.jfaas.runner.ObjectTestBeanLocal", "network.golem.jfaas.runner.ObjectTestBean", "convertFail", new Object[]{argument}};
+        Object[] invocation = {null, "network.golem.jfaas.runner.ObjectTestBean", "convertFail", new Object[]{argument}};
 
         Path invocationFilePath = Paths.get(tempDir, invocationId + ".invocation");
         try (OutputStream fileOutputStream = Files.newOutputStream(invocationFilePath)) {
@@ -62,7 +62,7 @@ public class ObjectTest {
         String tempDir = System.getProperty("java.io.tmpdir");
 
         ObjectTestArgument argument = new ObjectTestArgument("object", "test");
-        Object[] invocation = {"network.golem.jfaas.runner.ObjectTestBeanLocal", "network.golem.jfaas.runner.ObjectTestBean", "convertToNull", new Object[]{argument}};
+        Object[] invocation = {null, "network.golem.jfaas.runner.ObjectTestBean", "convertToNull", new Object[]{argument}};
 
         Path invocationFilePath = Paths.get(tempDir, invocationId + ".invocation");
         try (OutputStream fileOutputStream = Files.newOutputStream(invocationFilePath)) {
@@ -75,5 +75,26 @@ public class ObjectTest {
 
         Path returnFilePath = Paths.get(tempDir, invocationId + ".invocation.return");
         assertTrue(Files.isRegularFile(returnFilePath));
+    }
+
+    @Test
+    public void voidTest() throws Throwable {
+        String invocationId = Long.toString(Math.abs(new Random().nextLong()));
+        String tempDir = System.getProperty("java.io.tmpdir");
+
+        Object argument = "notNUll";
+        Object[] invocation = {null, "network.golem.jfaas.runner.ObjectTestBean", "nullValidate", new Object[]{argument}};
+
+        Path invocationFilePath = Paths.get(tempDir, invocationId + ".invocation");
+        try (OutputStream fileOutputStream = Files.newOutputStream(invocationFilePath)) {
+            try (ObjectOutputStream out = new ObjectOutputStream(fileOutputStream)) {
+                out.writeObject(invocation);
+            }
+        }
+
+        JfaasRunner.invoke(invocationFilePath);
+
+        Path returnFilePath = Paths.get(tempDir, invocationId + ".invocation.return");
+        assertTrue(Files.exists(returnFilePath) && Files.isRegularFile(returnFilePath));
     }
 }

--- a/jfaas-runner/src/test/java/network/golem/jfaas/runner/ObjectTestBean.java
+++ b/jfaas-runner/src/test/java/network/golem/jfaas/runner/ObjectTestBean.java
@@ -15,4 +15,9 @@ public class ObjectTestBean implements ObjectTestBeanLocal {
     public ObjectTestReturn convertToNull(ObjectTestArgument argument) {
         return null;
     }
+    @Override
+    public void nullValidate(Object argument) {
+        if (argument == null)
+            throw new RunnerException("object is null");
+    }
 }

--- a/jfaas-runner/src/test/java/network/golem/jfaas/runner/ObjectTestBeanLocal.java
+++ b/jfaas-runner/src/test/java/network/golem/jfaas/runner/ObjectTestBeanLocal.java
@@ -3,5 +3,6 @@ package network.golem.jfaas.runner;
 public interface ObjectTestBeanLocal {
     public ObjectTestReturn convert(ObjectTestArgument argument);
     public ObjectTestReturn convertFail(ObjectTestArgument argument) throws ObjectTestException;
-    ObjectTestReturn convertToNull(ObjectTestArgument argument);
+    public ObjectTestReturn convertToNull(ObjectTestArgument argument);
+    public void nullValidate(Object argument);
 }


### PR DESCRIPTION
The jfaas proxy executes the call asynchronously if the method returns `Future<>` type.
Additional minor change is that the jfaas proxy does not send the interface class name to a remote side anymore. The first element is null at the moment - it will be a serialized target object.